### PR TITLE
33 export split df

### DIFF
--- a/torchdms/cli.py
+++ b/torchdms/cli.py
@@ -72,21 +72,12 @@ def cli():
     we throw out the stratum completely.",
 )
 @option(
-    "--export",
-    type=bool,
-    required=False,
-    default=False,
-    show_default=True,
-    help="If True, exports the test and train partitions \
-    as dataframes in a .pkl file."
-)
-@option(
-    "--filename",
+    "--export-dataframe",
     type=str,
     required=False,
-    default='partitioned_data',
-    show_default=True,
-    help="This is the filename for your exported data."
+    default=None,
+    help="Filename for exporting the original dataframe \
+    in a .pkl file with an appended in_test column.",
 )
 @click_config_file.configuration_option(implicit=False, provider=json_provider)
 def prep(
@@ -95,8 +86,7 @@ def prep(
     targets,
     per_stratum_variants_for_test,
     skip_stratum_if_count_is_smaller_than,
-    export,
-    filename
+    export_dataframe
 ):
     """
     Prepare data for training.
@@ -118,8 +108,7 @@ def prep(
         aa_func_scores,
         per_stratum_variants_for_test,
         skip_stratum_if_count_is_smaller_than,
-        export,
-        filename
+        export_dataframe
     )
     for train_part in partitioned_train_data:
         num_subs = len(train_part["aa_substitutions"][0].split())

--- a/torchdms/data.py
+++ b/torchdms/data.py
@@ -9,6 +9,15 @@ from torch.utils.data import Dataset
 from collections import defaultdict
 import itertools
 import random
+from torchdms.utils import (
+    beta_coefficients,
+    evaluation_dict,
+    from_pickle_file,
+    to_pickle_file,
+    monotonic_params_from_latent_space,
+    latent_space_contour_plot_2D,
+    plot_test_correlation,
+)
 
 
 class BinaryMapDataset(Dataset):
@@ -49,8 +58,7 @@ def partition(
     aa_func_scores,
     per_stratum_variants_for_test=100,
     skip_stratum_if_count_is_smaller_than=250,
-    export=False,
-    filename='partitioned_data'
+    export_dataframe=None
 ):
     """
     Partition the data into a test partition, and a list of training data partitions.
@@ -91,10 +99,9 @@ def partition(
     test_partition = aa_func_scores.loc[aa_func_scores["in_test"] == True,].reset_index(
         drop=True
     )
-    
-    if export==True:
-    with open(f"{filename}.pkl", "wb") as f:
-        pickle.dump([test_partition, partitioned_train_data], f)
+
+    if export_dataframe != None:
+        to_pickle_file(aa_func_scores, f'{export_dataframe}')
 
     return test_partition, partitioned_train_data
 


### PR DESCRIPTION
Opening this to start a discussion around how best to export dataframes that have been split into train and test sets by torchdms, for global epistasis modeling using dms_variants. Currently, I've added the flags `--export` and `--filename` to `tdms prep`, which allows you to dump the separated dataframes `test_partition` and `partitioned_train_data` (stratified by n-mutants). But it might be preferable to export a single dataframe with an `in_test` column.