### PR TITLE
135-model-name-cleanup

### DIFF
--- a/torchdms/model.py
+++ b/torchdms/model.py
@@ -501,7 +501,7 @@ class FullyConnected(TorchdmsModel):
             monotonic = "mono"
         return f"{monotonic};" + ";".join(
             [
-                f"{dim};{name}"
+                f"{dim};{name.__name__}"
                 for dim, name in zip(self.internal_layer_dimensions, self.activations)
             ]
         )


### PR DESCRIPTION
## Description

Instead of returning the entire callable object of the `torch.nn` classes when calling `model.str_summary()`, just return the ``__name__``.

Closes #135 


## Tests

Please describe the tests added to verify correct behavior.
No unit tests here -- but scatterplots look like this again after a good ole' `make test`.

<img width="437" alt="Screen Shot 2021-10-08 at 10 56 30 AM" src="https://user-images.githubusercontent.com/29761930/136601624-b3ca6007-0570-4afd-a152-9597fbe2bcef.png">

## Checklist:



* [X] The code uses informative and accurate variable and function names
* [X] The functionality is factored out into functions and methods with logical interfaces
* [X] Comments are up to date, document intent, and there are no commented-out code blocks
* [X] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [X] TODOs have been eliminated from the code
* [X] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
* [ ] Documentation has been redeployed
