### PR TITLE
Bug-fix for PyTorch activations without `__name__` attribute

### DIFF
--- a/torchdms/model.py
+++ b/torchdms/model.py
@@ -502,6 +502,8 @@ class FullyConnected(TorchdmsModel):
         return f"{monotonic};" + ";".join(
             [
                 f"{dim};{name.__name__}"
+                if hasattr(name, "__name__")
+                else f"{dim};{name}"
                 for dim, name in zip(self.internal_layer_dimensions, self.activations)
             ]
         )


### PR DESCRIPTION
## Description

Some activation classes don't have an attribute  `__name__` (i.e., `nn.Identity()`), which could cause issues (in fact, while `make test` seems to pass all checks, running experiments with the same code seems to fail when calling `FullyConnected.str_summary()` for some reason...). Defaulting to sending the callable object if this is the case. Just to at least get my CGG-experiments up and running again.

Closes #135 (again -- kinda)


## Tests

N/a


## Checklist:

* [X] The code uses informative and accurate variable and function names
* [X] The functionality is factored out into functions and methods with logical interfaces
* [X] Comments are up to date, document intent, and there are no commented-out code blocks
* [X] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [X] TODOs have been eliminated from the code
* [X] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
* [ ] Documentation has been redeployed
