### PR TITLE
passing 'go' command

### DIFF
--- a/torchdms/cli.py
+++ b/torchdms/cli.py
@@ -505,7 +505,6 @@ def train(
                 "weight decay will be turned off."
             )
             loss_weight_span = None
-    # else:
     if loss_weight_span is not None:
         click.echo(
             "NOTE: you are using loss decays, which assumes that you want to up-weight "
@@ -567,7 +566,6 @@ def default_map_of_ctx_or_parent(ctx):
 @click.option(
     "--show-points", is_flag=True, help="Show points in addition to LOWESS curves."
 )
-# @click.option("--device", type=str, required=False, default="cpu")
 @click.option(
     "--include-details",
     is_flag=True,
@@ -575,17 +573,11 @@ def default_map_of_ctx_or_parent(ctx):
 )
 @click_config_file.configuration_option(implicit=False, provider=json_provider)
 @click.pass_context
-#def error(ctx, model_path, data_path, out, show_points, device, include_details):
 def error(ctx, model_path, data_path, out, show_points, include_details):
     """Evaluate and produce plot of error."""
-    #device=torch.device(device)
-    model = torch.load(model_path, map_location=torch.device('cpu'))
-    #model.to(device)
+    model = torch.load(model_path, map_location=torch.device("cpu"))
     prefix = os.path.splitext(out)[0]
-
     data = from_pickle_file(data_path)
-    #data.test.samples = data.test.samples.to(device)
-    #data.test.targets = data.test.targets.to(device)
 
     evaluation = build_evaluation_dict(model, data.test)
     error_df = error_df_of_evaluation_dict(evaluation)
@@ -608,16 +600,12 @@ def error(ctx, model_path, data_path, out, show_points, include_details):
 @click.argument("model_path", type=click.Path(exists=True))
 @click.argument("data_path", type=click.Path(exists=True))
 @click.option("--out", required=True, type=click.Path())
-# @click.option("--device", type=str, required=False, default="cpu")
 @click_config_file.configuration_option(implicit=False, provider=json_provider)
-#def scatter(model_path, data_path, out, device):
 def scatter(model_path, data_path, out):
     """Evaluate and produce scatter plot of observed vs predicted targets on
     the test set provided."""
-    model = torch.load(model_path, map_location=torch.device('cpu'))
+    model = torch.load(model_path, map_location=torch.device("cpu"))
     data = from_pickle_file(data_path)
-    #data.test.samples = data.test.samples.to(device)
-    #data.test.targets = data.test.targets.to(device)
     evaluation = build_evaluation_dict(model, data.test)
     plot_test_correlation(evaluation, model, out)
     click.echo(f"LOG: scatter plot finished and dumped to {out}")
@@ -630,15 +618,14 @@ def scatter(model_path, data_path, out):
 @click_config_file.configuration_option(implicit=False, provider=json_provider)
 def beta(model_path, data_path, out):
     """Plot beta coefficients as a heatmap."""
-    model = torch.load(model_path, map_location=torch.device('cpu'))
+    model = torch.load(model_path, map_location=torch.device("cpu"))
     data = from_pickle_file(data_path)
     click.echo(
         f"LOG: loaded data, evaluating beta coeff for wildtype seq: {data.test.wtseq}"
     )
     beta_coefficients(model, data.test, out)
     click.echo(f"LOG: Beta coefficients plotted and dumped to {out}")
-######################
-######################
+
 
 @cli.command()
 @click.argument("model_path", type=click.Path(exists=True))
@@ -651,7 +638,7 @@ def heatmap(model_path, data_path, out):
     Note/warning: because of the way we have set up the encoding, the heatmap values
     cannot be interpreted in a straightfoward way.
     """
-    model = torch.load(model_path, map_location=torch.device('cpu'))
+    model = torch.load(model_path, map_location=torch.device("cpu"))
     data = from_pickle_file(data_path)
     click.echo(
         f"LOG: loaded data, calculating single mutant predictions from WT seq: {data.test.wtseq}"
@@ -665,14 +652,11 @@ def heatmap(model_path, data_path, out):
 @click.argument("data_path", type=click.Path(exists=True))
 @click.option("--steps", required=False, type=int, default=100, show_default=True)
 @click.option("--out", required=True, type=click.Path())
-#@click.option("--device", type=str, required=False, default="cpu")
 @click_config_file.configuration_option(implicit=False, provider=json_provider)
-#def geplot(model_path, data_path, steps, out, device):
 def geplot(model_path, data_path, steps, out):
     """Make a "global epistasis" plot showing the fit to the nonlinearity."""
-    model = torch.load(model_path, map_location=torch.device('cpu'))
+    model = torch.load(model_path, map_location=torch.device("cpu"))
     data = from_pickle_file(data_path)
-    #geplot_df = build_geplot_df(model, data.test, device)
     geplot_df = build_geplot_df(model, data.test)
     if model.latent_dim == 1:
         plot_geplot(geplot_df, out, model.str_summary())
@@ -693,14 +677,13 @@ def geplot(model_path, data_path, steps, out):
 @click_config_file.configuration_option(implicit=False, provider=json_provider)
 def svd(model_path, data_path, out):
     """Plot singular values of beta matricies."""
-    model = torch.load(model_path, map_location=torch.device('cpu'))
+    model = torch.load(model_path, map_location=torch.device("cpu"))
     data = from_pickle_file(data_path)
     click.echo("LOG: model loaded, calculating SVD for beta coefficents.")
     plot_svd(model, data.test, out)
     click.echo(f"LOG: Singular values of beta plotted and dumped to {out}")
 
 
-# Plot protein profiles
 @cli.command()
 @click.argument("model_path", type=click.Path(exists=True))
 @click.argument("data_path", type=click.Path(exists=True))
@@ -708,7 +691,7 @@ def svd(model_path, data_path, out):
 @click_config_file.configuration_option(implicit=False, provider=json_provider)
 def profiles(model_path, data_path, out):
     """Plot amino acid and site profiles from low-rank approximation."""
-    model = torch.load(model_path, map_location=torch.device('cpu'))
+    model = torch.load(model_path, map_location=torch.device("cpu"))
     data = from_pickle_file(data_path)
     click.echo("LOG: model loaded, plotting amino acid and site profiles.")
     plot_svd_profiles(model, data.test, out)

--- a/torchdms/evaluation.py
+++ b/torchdms/evaluation.py
@@ -24,18 +24,12 @@ def build_evaluation_dict(model, test_data, device="cpu"):
     assert test_data.feature_count() == model.input_size
     assert test_data.target_count() == model.output_size
     model.eval()
-    #if device != "cpu":
-    #    samples = test_data.samples.detach().cpu().numpy()
-    #    predictions = model(test_data.samples.to(device))
-    #    predictions = predictions.detach().cpu().numpy()
-    #    targets = test_data.targets.cpu().numpy()
-    #else:
     samples = test_data.samples.detach().numpy()
     predictions = model(test_data.samples.to(device)).detach().numpy()
     targets = test_data.targets.detach().numpy()
-    
+
     return {
-        "samples": samples ,
+        "samples": samples,
         "predictions": predictions,
         "targets": targets,
         "original_df": test_data.original_df,
@@ -83,9 +77,7 @@ def error_summary_of_error_df(error_df, model):
 
 
 def error_summary_of_data(data, model, split_label=None, **kwargs):
-    error_df = error_df_of_evaluation_dict(
-        build_evaluation_dict(model, data, **kwargs)
-    )
+    error_df = error_df_of_evaluation_dict(build_evaluation_dict(model, data, **kwargs))
     error_summary_df = error_summary_of_error_df(error_df, model)
     if split_label is not None:
         error_summary_df["split_label"] = split_label


### PR DESCRIPTION
## Description

Please include a summary of the change.

This PR pretty much just forces the plotting eval functions to use cpu, so that we can easily put the "device : "cuda", 
parameter into option.json in torch-dms-experiments and train on gpu's

Needs lots of cleanup

Closes #(replace this parenthetical with issue number)


## Tests

Please describe the tests added to verify correct behavior.


## Checklist:

* [ ] The code uses informative and accurate variable and function names
* [ ] The functionality is factored out into functions and methods with logical interfaces
* [ ] Comments are up to date, document intent, and there are no commented-out code blocks
* [ ] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [ ] TODOs have been eliminated from the code
* [ ] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
* [ ] Documentation has been redeployed
